### PR TITLE
Add bulk delete endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-stretch as builder
+FROM golang:1.10.2-stretch as builder
 
 ARG VERSION
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ REGISTRY = eu.gcr.io/mirakl-production/kube/mp
 REMOTE_NAME = ${REGISTRY}/${NAME}
 
 GOPATH ?= ${HOME}/go
-VERSION ?= 1.1.0
+VERSION ?= 1.2.0
 
 LDFLAGS=-ldflags "-X main.version=${VERSION}"
 
@@ -38,10 +38,11 @@ end2end-test: docker-image
 	VERSION=${VERSION} docker-compose -f ./test/docker-compose.yml down
 
 docker-image: check-version
-	docker build . -t mirakl/${NAME}:${VERSION} -t ${REMOTE_NAME}:${VERSION} --build-arg VERSION=${VERSION}
+	docker build . -t mirakl/${NAME}:${VERSION} -t ${REMOTE_NAME}:${VERSION} -t ${REMOTE_NAME}:latest --build-arg VERSION=${VERSION}
 
 docker-image-push: docker-image
 	docker push ${REMOTE_NAME}:${VERSION}
+	docker push ${REMOTE_NAME}:latest
 
 check-version:
 ifndef VERSION

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ s3proxy responds directly to the following endpoints.
 * Delete object : `DELETE /api/v1/object/:bucket/:key`  
     - return an 200 OK response : delete the object defined by the bucket and the key
     
+* Bulk Delete object : `POST /api/v1/object/delete/:bucket` with a body containing list of keys "key=...&key=..."  
+    - return an 200 OK response : delete the object defined by the bucket and the key
+    - return 400 Bad request if key parameter is missing
+
 * Copy object : `POST /api/v1/object/copy/:bucket/:key?destBucket=...&destKey=...`
     - return an 200 OK : copy the object defined by the bucket and the key to the destBucket and destKey
     - return 400 Bad request if destBucket or destKey are missing
@@ -201,6 +205,18 @@ curl -H "Authorization: ${API_KEY}" -X DELETE \
 Response : HTTP CODE 200
 
 `{"response" : "ok"}`
+
+* Bulk delete an object :
+
+```
+curl -H "Authorization: ${API_KEY}" -d "key=/folder1/file1.txt&key=/folder1/file2.txt" \ 
+    http://localhost:8080/api/v1/object/my-bucket`
+```
+
+Response : HTTP CODE 200
+
+`{"response" : "ok"}`
+
 
 * Copy an object :
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -16,6 +16,9 @@ type Backend interface {
 	// DeleteObject delete an object in a bucket
 	DeleteObject(object BucketObject) error
 
+	// BatchDeleteObject delete an object in a bucket
+	BatchDeleteObjects(objects []BucketObject) error
+
 	// CopyObject copies one item from a bucket to another
 	// sourceObject : source object (ex: mybucket and /folder/item)
 	// destinationObject : destination object (ex: mybucket and /folder/item2)

--- a/backend/backendtest/s3fakebackend.go
+++ b/backend/backendtest/s3fakebackend.go
@@ -58,6 +58,10 @@ func (b *S3FakeBackend) DeleteObject(object backend.BucketObject) error {
 	return nil
 }
 
+func (b *S3FakeBackend) BatchDeleteObjects(objects []backend.BucketObject) error {
+	return nil
+}
+
 // Fake copy, does nothing except returning some errors when the keyword "notfound" are used
 func (b *S3FakeBackend) CopyObject(sourceObject backend.BucketObject, destinationObject backend.BucketObject) error {
 	if strings.Contains(sourceObject.BucketName, "notfound") || strings.Contains(destinationObject.BucketName, "notfound") {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.5"
+
+services:
+
+  s3proxy:
+    image: eu.gcr.io/mirakl-production/kube/mp/s3proxy:latest
+    depends_on:
+      - createbuckets
+    ports:
+      - 9080:9080
+    environment:
+      - "AWS_REGION=eu-west-1"
+      - "S3PROXY_HTTP_PORT=9080"
+      - "S3PROXY_USE_MINIO=localhost:9000"
+      - "S3PROXY_MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE"
+      - "S3PROXY_MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    command: s3proxy
+
+  minio:
+    image: minio/minio
+    ports:
+      - 9000:9000
+    environment:
+      - "MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE"
+      - "MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    command: server /export
+
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      /bin/sleep 5;
+      /usr/bin/mc config host add myminio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY;
+      /usr/bin/mc rm -r --force myminio/test;
+      /usr/bin/mc mb myminio/test;
+      /usr/bin/mc policy download myminio/test;
+      exit 0;
+      "

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+set -e
+
+trap "docker-compose down" SIGINT SIGQUIT SIGTERM TERM EXIT
+
+docker-compose up

--- a/s3proxy_test.go
+++ b/s3proxy_test.go
@@ -105,6 +105,19 @@ func TestDeleteOK(t *testing.T) {
 	}
 }
 
+func TestBulkDeleteOK(t *testing.T) {
+	w := s3proxytest.ServeBulkDeleteObject(t, r, dummyBucket, []string{"/toto/file1", "/toto/file2", "/toto/file2"}, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	objmap := unmarshallJSON(t, w.Body.Bytes())
+	assert.Contains(t, objmap["response"], "ok")
+}
+
+func TestBulkDelete400BadRequest(t *testing.T) {
+	w := s3proxytest.ServeBulkDeleteObject(t, r, dummyBucket, []string{}, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestCopyOK(t *testing.T) {
 	w := s3proxytest.ServeCopyObject(t, r, dummyBucket, dummyFile, dummyBucket, dummyFile+"2", "")
 	assert.Equal(t, http.StatusOK, w.Code)


### PR DESCRIPTION
A new endpoint has been added for deleting list of keys.
The endpoint has been added to the api group object with the following signature :

POST /api/v1/object/delete/:bucket with a body paylod as follow : key=...&key=...