### PR TITLE
Get rid of the s3proxy syslog mtype in favor of the generic mtype

### DIFF
--- a/logger/logging.go
+++ b/logger/logging.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"log/syslog"
 	"os"
 
@@ -22,7 +23,14 @@ func init() {
 
 // Add logging to stdout with rsyslog
 func AddRsyslogBackend(host string) error {
-	backend, err := NewRSyslogBackend("s3proxy", host, syslog.LOG_LOCAL0, "s3proxy_none_none_central")
+	const (
+		mtype     = "generic"
+		mserver   = "s3proxy"
+		menv      = "none"
+		namespace = "central"
+	)
+
+	backend, err := NewRSyslogBackend(host, syslog.LOG_LOCAL0, fmt.Sprintf("%s_%s_%s_%s", mtype, mserver, menv, namespace))
 	if err != nil {
 		return err
 	}

--- a/logger/rsyslog.go
+++ b/logger/rsyslog.go
@@ -12,7 +12,7 @@ type RSyslogBackend struct {
 }
 
 // Create a new RSyslog backend
-func NewRSyslogBackend(prefix string, host string, priority syslog.Priority, tag string) (b *RSyslogBackend, err error) {
+func NewRSyslogBackend(host string, priority syslog.Priority, tag string) (b *RSyslogBackend, err error) {
 	var w *syslog.Writer
 	w, err = syslog.Dial("udp", host, priority, tag)
 	return &RSyslogBackend{w}, err


### PR DESCRIPTION
In this PR https://github.com/mirakl/production/pull/4325
I added a `generic` mtype which simply routes the logs to
`${namespace}/${mserver}.log`.

This PR changes s3proxy to make use of thar routing rule instead of the
`s3proxy` specific one so that we can cleanup the logstash config.