### PR TITLE
Get rid off AAAA DNS queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.2-stretch as builder
+FROM golang:1.10.2-stretch as app-builder
 
 ARG VERSION
 
@@ -20,12 +20,26 @@ COPY *.go ./
 
 RUN make VERSION=${VERSION}
 
+
+FROM golang:1.10.2-stretch as lib-builder
+
+WORKDIR /root
+RUN git clone https://github.com/damienleger/dns-aaaa-no-more.git && \
+    cd dns-aaaa-no-more && \
+    make
+
+
 FROM centos:latest
 
-COPY --from=builder /go/src/github.com/mirakl/s3proxy /bin
+COPY --from=lib-builder /root/dns-aaaa-no-more/getaddrinfo.so /dns-aaaa-no-more/
+COPY --from=app-builder /go/src/github.com/mirakl/s3proxy /bin
 RUN chmod +x /bin/s3proxy
 
 EXPOSE 8080
 
 USER nobody
-ENTRYPOINT ["s3proxy"]
+
+# To fix DNS issues in K8S caused by conntrack race condition (A/AAAA sent in parallel):
+# - cgo resolver is enforced (see https://golang.org/pkg/net/#hdr-Name_Resolution)
+# - getaddrinfo() C function called by cgo resolver is hooked to a new one not sending AAAA DNS requests
+ENTRYPOINT GODEBUG=netdns=cgo LD_PRELOAD=/dns-aaaa-no-more/getaddrinfo.so exec /bin/s3proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN make VERSION=${VERSION}
 FROM golang:1.10.2-stretch as lib-builder
 
 WORKDIR /root
-RUN git clone https://github.com/damienleger/dns-aaaa-no-more.git && \
+RUN git clone https://github.com/mirakl/dns-aaaa-no-more.git && \
     cd dns-aaaa-no-more && \
     make
 


### PR DESCRIPTION
To fix DNS issues in K8S caused by conntrack race condition (A/AAAA sent in parallel):
- cgo resolver is enforced (see golang.org/pkg/net/#hdr-Name_Resolution)
- getaddrinfo() C function called by cgo resolver is hooked to a new one not sending AAAA DNS requests