### PR TITLE
Fix VERSION variable to work with dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.15-buster as app-builder
 
-ARG VERSION
-
 ENV SRC_DIR /s3proxy
 WORKDIR $SRC_DIR
 
@@ -15,7 +13,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make VERSION=${VERSION}
+RUN make 
 
 FROM golang:1.15-buster as lib-builder
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME = s3proxy
 REMOTE_NAME = ${REGISTRY}${NAME}
 
 GOPATH ?= ${HOME}/go
-VERSION ?= 1.2.1
+VERSION ?= 1.2.2
 
 LDFLAGS=-ldflags "-X main.version=${VERSION}"
 
@@ -36,15 +36,15 @@ integration-test: docker-build-image
 	docker-compose -f ./test/docker-compose.yml down
 
 end2end-test: docker-build-image
-	VERSION=${VERSION} docker-compose -f ./test/docker-compose.yml up -d
+	docker-compose -f ./test/docker-compose.yml up -d
 	docker run --rm --net=s3proxy-network -i mirakl/${NAME}-build go test -v ./test -tags=end2end
-	VERSION=${VERSION} docker-compose -f ./test/docker-compose.yml down
+	docker-compose -f ./test/docker-compose.yml down
 
 docker-image: check-version
 	docker build . -t mirakl/${NAME}:${VERSION} -t ${REMOTE_NAME}:${VERSION} -t ${REMOTE_NAME}:latest --build-arg VERSION=${VERSION}
 
 docker-build-image:
-	docker build . -t mirakl/${NAME}-build --target app-builder --build-arg VERSION=${VERSION}
+	docker build . -t mirakl/${NAME}-build --target app-builder
 
 docker-image-push: docker-image
 	docker push ${REMOTE_NAME}:${VERSION}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
 
   s3proxy:
-    image: mirakl/s3proxy:${VERSION}
+    image: mirakl/s3proxy-build:latest
     networks:
       - s3proxy-network
     depends_on:
@@ -16,7 +16,7 @@ services:
       - "S3PROXY_MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
       - "S3PROXY_USE_RSYSLOG=rsyslog:514"
       - "S3PROXY_API_KEY=3f300bdc-0028-11e8-ba89-0ed5f89f718b"
-    command: s3proxy
+    command: ./s3proxy
 
   rsyslog:
     image: voxxit/rsyslog


### PR DESCRIPTION
Currently the build & push image is managed by makefile. User should run
make command to build and push is our personnal repository.
We don't want it, and use dockerhub as default docker registry for s3proxy.

To deal with that:
 - Fix end2end integration test: this process should use an image
already builded pushed and available. I think it doesn't make sense
cause we have to run test before to push the final image. So at this
purpose use the "build" image to run test.
 - Remove VERSION variable used in Dockerfile: dockerhub launch directly
   the build with Dockerfile, which contains VERSION variable. BUT the
VERSION is never filled on dockerhub. So remove this VERSION on
dockerfile and use the VERSION provided in Makefile (which is launched
in Dockerfile)

Now if we need to build and push the new version on docker hub, just
create a tag on master should be enough.