### PR TITLE
Increase timeout for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	if [ -f "${NAME}" ] ; then rm ${NAME} ; fi
 
 lint: tools.golangci-lint
-	bin/golangci-lint run
+	bin/golangci-lint --timeout=300s run -v
 
 fmtcheck: tools.goimports
 	@echo "--> checking code formatting with 'goimports' tool"


### PR DESCRIPTION
On Dockerhub, when the build is running there is an error due to a
timeout exceeded for the golangci-lint.
Fix and increase the timeout for this step.