### PR TITLE
[PROD-6877] fix release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN git clone https://github.com/mirakl/dns-aaaa-no-more.git && \
 FROM centos:latest
 
 COPY --from=lib-builder /root/dns-aaaa-no-more/getaddrinfo.so /dns-aaaa-no-more/
-COPY --from=app-builder /s3proxy /bin
-RUN chmod +x /bin/s3proxy
+COPY --from=app-builder /s3proxy /usr/bin/
+RUN chmod +x /usr/bin/s3proxy
 
 EXPOSE 8080
 


### PR DESCRIPTION
use the real directory and not the centos symlinks

try to avoid this error:
```
[stage-2 3/4] COPY --from=app-builder /s3proxy /bin
sha256:b4feeb1780426b0ab6db25533fc316da0c598908e8299809215d68760370b002
ERROR: cannot copy to non-directory: /var/lib/docker/overlay2/ljbaa3lzbhm820bnsbbbjsh46/merged/usr/bin/logger
------
> [stage-2 3/4] COPY --from=app-builder /s3proxy /bin:
```