### PR TITLE
fix release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone https://github.com/mirakl/dns-aaaa-no-more.git && \
 FROM centos:latest
 
 COPY --from=lib-builder /root/dns-aaaa-no-more/getaddrinfo.so /dns-aaaa-no-more/
-COPY --from=app-builder /s3proxy /usr/bin/
+COPY --from=app-builder /s3proxy/s3proxy /usr/bin/
 RUN chmod +x /usr/bin/s3proxy
 
 EXPOSE 8080


### PR DESCRIPTION
same trouble:
```
[stage-2 3/4] COPY --from=app-builder /s3proxy /usr/bin/
sha256:1fc208a05de0260397d96da7933f0ca261c75059b4a921a4ebca236420bcd92a
ERROR: cannot copy to non-directory: /var/lib/docker/overlay2/yyh5ayusi4a1evxls9nt6sq9h/merged/usr/bin/logger
```