### PR TITLE
Fix Linter step in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,12 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Linter
-        run: make lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.46
   build:
     name: test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   lint:
@@ -21,6 +21,9 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+
+      - name: Code Formatting
+        run: make fmtcheck
 
       - name: Linter
         uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  timeout: 5m
 linters:
   enable:
     - goimports

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOFILES	= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 default: build
 
-build: clean fmtcheck lint
+build: clean
 	go build -i -v ${LDFLAGS} -o ${NAME}
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ build: clean fmtcheck lint
 clean:
 	if [ -f "${NAME}" ] ; then rm ${NAME} ; fi
 
-lint: tools.golangci-lint
-	bin/golangci-lint --timeout=300s run -v
+lint:
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.46.2 golangci-lint run -v
 
 fmtcheck: tools.goimports
 	@echo "--> checking code formatting with 'goimports' tool"
@@ -61,9 +61,4 @@ tools.goimports:
 		go install golang.org/x/tools/cmd/goimports@latest; \
 	fi
 
-tools.golangci-lint:
-	@command -v bin/golangci-lint >/dev/null ; if [ $$? -ne 0 ]; then \
-		echo "--> installing golangci-lint"; \
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.44.0; \
-	fi
 .PHONY: test


### PR DESCRIPTION
## Issue
golangci-lint is no longer available from https://install.goreleaser.com/github.com/golangci/golangci-lint.sh.

## Proposed fix

* locally: run golangci-lint using docker
* CI Github action: use https://github.com/golangci/golangci-lint-action
