### PR TITLE
Isolate and limit dependencies on S3

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -3,6 +3,8 @@ package backend
 import (
 	"fmt"
 	"time"
+
+	"github.com/go-errors/errors"
 )
 
 // Backend provides an interface for S3
@@ -38,3 +40,8 @@ func (b BucketObject) String() string {
 func (b BucketObject) FullPath() string {
 	return fmt.Sprintf("/%s%s", b.BucketName, b.Key)
 }
+
+var (
+	ErrBucketNotFound = errors.New("No such bucket")
+	ErrObjectNotFound = errors.New("No such key")
+)

--- a/backend/backendtest/s3fakebackend.go
+++ b/backend/backendtest/s3fakebackend.go
@@ -5,25 +5,20 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/mirakl/s3proxy/backend/s3backend"
+
 	"github.com/mirakl/s3proxy/backend"
 )
 
-// S3 implementation for a fake Backend Interface, all methods are the same except delete
-func NewS3FakeBackend(config ...backend.S3BackendConfig) (backend.Backend, error) {
-	return newS3FakeBackend(config)
-}
-
-func newS3FakeBackend(config []backend.S3BackendConfig) (*S3FakeBackend, error) {
-
-	var s3backend backend.Backend
+// New S3 implementation for a fake Backend Interface, all methods are the same except delete
+func New(config ...s3backend.Config) (backend.Backend, error) {
+	var s3Backend backend.Backend
 	var err error
 
 	if len(config) == 0 {
-		s3backend, err = backend.NewS3Backend()
+		s3Backend, err = s3backend.New()
 	} else {
-		s3backend, err = backend.NewS3Backend(config[0])
+		s3Backend, err = s3backend.New(config[0])
 	}
 
 	if err != nil {
@@ -31,45 +26,45 @@ func newS3FakeBackend(config []backend.S3BackendConfig) (*S3FakeBackend, error) 
 	}
 
 	// Create S3 service client
-	return &S3FakeBackend{
-		s3Backend: s3backend,
+	return &impl{
+		s3Backend: s3Backend,
 	}, nil
 }
 
 // Fake s3 backend implementation
-type S3FakeBackend struct {
+type impl struct {
 	s3Backend backend.Backend
 }
 
-// Create presigned url for upload just like for a real s3 backend
-func (b *S3FakeBackend) CreatePresignedURLForUpload(object backend.BucketObject, expire time.Duration) (string, error) {
+// CreatePresignedURLForUpload creates presigned url for upload just like for a real s3 backend
+func (b *impl) CreatePresignedURLForUpload(object backend.BucketObject, expire time.Duration) (string, error) {
 	return b.s3Backend.CreatePresignedURLForUpload(object, expire)
 }
 
-// Create presigned url for download just like for a real s3 backend
-func (b *S3FakeBackend) CreatePresignedURLForDownload(object backend.BucketObject, expire time.Duration) (string, error) {
+// CreatePresignedURLForDownload creates presigned url for download just like for a real s3 backend
+func (b *impl) CreatePresignedURLForDownload(object backend.BucketObject, expire time.Duration) (string, error) {
 	return b.s3Backend.CreatePresignedURLForDownload(object, expire)
 }
 
-// Delete action for an object in a bucket, in our case does nothing because no real backend
-func (b *S3FakeBackend) DeleteObject(object backend.BucketObject) error {
+// DeleteObject delete action for an object in a bucket, in our case does nothing because no real backend
+func (b *impl) DeleteObject(object backend.BucketObject) error {
 	if strings.Contains(object.Key, "error") {
 		panic("Fake panic :))")
 	}
 	return nil
 }
 
-func (b *S3FakeBackend) BatchDeleteObjects(objects []backend.BucketObject) error {
+func (b *impl) BatchDeleteObjects(objects []backend.BucketObject) error {
 	return nil
 }
 
 // Fake copy, does nothing except returning some errors when the keyword "notfound" are used
-func (b *S3FakeBackend) CopyObject(sourceObject backend.BucketObject, destinationObject backend.BucketObject) error {
+func (b *impl) CopyObject(sourceObject backend.BucketObject, destinationObject backend.BucketObject) error {
 	if strings.Contains(sourceObject.BucketName, "notfound") || strings.Contains(destinationObject.BucketName, "notfound") {
-		return awserr.New(s3.ErrCodeNoSuchBucket, "No such bucket", nil)
+		return backend.ErrBucketNotFound
 	}
 	if strings.Contains(sourceObject.Key, "notfound") {
-		return awserr.New(s3.ErrCodeNoSuchKey, "No such key", nil)
+		return backend.ErrObjectNotFound
 	}
 	return nil
 }

--- a/s3proxytest/s3proxytest.go
+++ b/s3proxytest/s3proxytest.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mirakl/s3proxy/backend/s3backend"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gin-gonic/gin"
 	"github.com/go-errors/errors"
-	"github.com/mirakl/s3proxy/backend"
 	logging "github.com/op/go-logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ var (
 
 	URLExpiration      = 15 * time.Minute
 	ServerAPIKey       = "3f300bdc-0028-11e8-ba89-0ed5f89f718b"
-	MinioBackendConfig = backend.S3BackendConfig{
+	MinioBackendConfig = s3backend.Config{
 		Host:             "minio:9000",
 		Region:           "eu-west-1",
 		AccessKey:        "AKIAIOSFODNN7EXAMPLE",
@@ -94,7 +95,7 @@ func WaitForS3proxy(t *testing.T, s3proxyHost string) {
 }
 
 // WaitForBucket is waiting for minio is up and bucket has been created
-func WaitForBucket(t *testing.T, bucketName string, config backend.S3BackendConfig) {
+func WaitForBucket(t *testing.T, bucketName string, config s3backend.Config) {
 
 	s3Config := &aws.Config{
 		Credentials:      credentials.NewStaticCredentials(config.AccessKey, config.SecretKey, ""),

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -10,8 +10,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/mirakl/s3proxy/backend/s3backend"
+
 	"github.com/gin-gonic/gin"
-	"github.com/mirakl/s3proxy/backend"
 	"github.com/mirakl/s3proxy/logger"
 	"github.com/mirakl/s3proxy/router"
 	"github.com/mirakl/s3proxy/s3proxytest"
@@ -38,7 +39,7 @@ func setupIntegration(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	s3Backend, err := backend.NewS3Backend(s3proxytest.MinioBackendConfig)
+	s3Backend, err := s3backend.New(s3proxytest.MinioBackendConfig)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Goal

The goal is to prepare the codebase to support using Google Cloud Storage as a backend.
I decided to split the PR to add support for GCS into smaller/easier to review chunks.

## Changes:

* Move S3 backend to own package `s3backend`, as an implementation of the generic `backend` package
* Simplify/Cleanup naming, e.g. `s3backend.New` instead of `backend.NewS3Backend`, `s3backend.Config` instead of `backend.S3BackendConfig`, ...
* Isolate the main package from AWS/S3 specific errors
