### PR TITLE
docs: better comment for RedirectTrailingSlash

### DIFF
--- a/s3proxy.go
+++ b/s3proxy.go
@@ -121,7 +121,7 @@ func main() {
 
 	router := router.NewGinEngine(gin.ReleaseMode, version, urlExpiration, serverAPIKey, s3Backend)
 
-	router.RedirectTrailingSlash = false // try to keep the same behavior as gin 1.7
+	router.RedirectTrailingSlash = false // return 404 when a <path> is not found instead redirecting to <path> + "/"
 
 	logStartupInfo()
 

--- a/s3proxy_test.go
+++ b/s3proxy_test.go
@@ -43,7 +43,7 @@ func setup() {
 	}
 
 	r = router.NewGinEngine(gin.TestMode, s3proxyVersion, expiration, "", s3backend)
-	r.RedirectTrailingSlash = false // try to keep the same behavior as gin 1.7
+	r.RedirectTrailingSlash = false // return 404 when a <path> is not found instead redirecting to <path> + "/"
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
add this comment for `RedirectTrailingSlash`:
```
return 404 when a <path> is not found instead redirecting to <path> + "/"
```