### PR TITLE
feat(DEVEX-1339): enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci:"


### PR DESCRIPTION
## Why

This repo's workflows currently pin several `actions/*` to majors that still run on Node 20 or older. Without Dependabot watching the `github-actions` ecosystem, those pins never get refreshed automatically.

Tracking: [DEVEX-1339](https://mirakl.atlassian.net/browse/DEVEX-1339) — org-wide effort to bump all third-party `actions/*` to Node-24-capable majors. Inventory for this repo: 5 outdated references across the workflows.

## What

Adds `.github/dependabot.yml` with a single `github-actions` update entry (weekly, `ci:` commit prefix). Mirrors the minimal config already used in the `github-repositories` Terraform repo.

Once merged, Dependabot will open `ci: bump actions/<name> ...` PRs against the existing workflows. Owning team can merge them at its own pace.

[DEVEX-1339]: https://mirakl.atlassian.net/browse/DEVEX-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ